### PR TITLE
BAU Don't use poetry >= 2.0.0

### DIFF
--- a/Dockerfile.batect
+++ b/Dockerfile.batect
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY poetry.lock .
 COPY pyproject.toml .
 
-RUN pip3 install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple/ --upgrade poetry<2.0.0
+RUN pip3 install --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple/ --upgrade "poetry<2.0.0"
 RUN poetry install
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
The [ecs-appmesh-task-helper pipeline](https://jenkins.tools.management.tax.service.gov.uk/job/products/job/tenant-compute/job/container/job/ecs-appmesh-task-helper-main/) has started to fail because poetry has had a major upgrade. 

This PR pins poetry to a version below 2.0.0, which introduced the breaking change, pending work to support the later version in [INFRA-8471](https://jira.tools.tax.service.gov.uk/browse/INFRA-8471).

